### PR TITLE
Add a line in _config.yml to fix the timezone issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,3 +33,6 @@ address:
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+# To fix Github timezone difference issue
+future: true


### PR DESCRIPTION
Add a line in _config.yml to fix the timezone issue. 

Everything looked fine on my local copy, but Github is not showing the update. A possible issue is my laptop's local time is seemed as future compared to Github's time. Adding future: true in _config.yml might solve the issue.